### PR TITLE
Fix crescendo JSON parsing crash producing zero results (#5058399)

### DIFF
--- a/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_foundry/_scenario_orchestrator.py
+++ b/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/red_team/_foundry/_scenario_orchestrator.py
@@ -112,7 +112,19 @@ class ScenarioOrchestrator:
 
         # Run attack - PyRIT handles all execution
         self.logger.info(f"Executing attacks for {self.risk_category}...")
-        self._scenario_result = await self._scenario.run_async()
+        try:
+            self._scenario_result = await self._scenario.run_async()
+        except Exception as e:
+            self.logger.warning(
+                f"Error during attack execution for {self.risk_category}: {str(e)}. "
+                f"Partial results may still be available."
+            )
+            # Try to retrieve partial results from the scenario
+            try:
+                if self._scenario and hasattr(self._scenario, "_result"):
+                    self._scenario_result = self._scenario._result
+            except Exception:
+                pass
 
         self.logger.info(f"Attack execution complete for {self.risk_category}")
 


### PR DESCRIPTION
## Bug Fix: #5058399

When Foundry crescendo orchestration returns non-JSON responses (e.g., raw markdown), the ScenarioOrchestrator now catches the error gracefully instead of propagating it. Partial results from successful attack strategies (e.g., baseline) are preserved even when other strategies fail.

### Changes
- Wrapped run_async() in try/except in ScenarioOrchestrator.execute()
- Logs warnings for attack execution errors
- Attempts to retrieve partial results from the scenario on failure